### PR TITLE
Dynamically load in the Spotify SDK, various fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://sdk.scdn.co/spotify-player.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,8 @@
 import { Header } from "./components/Header.tsx";
 import { SpotifyLogin } from "./components/SpotifyLogin.tsx";
-import {
-  checkSpotifyAccessToken,
-  refreshToken,
-} from "./util/checkSpotifyAccessToken.ts";
+import { checkSpotifyAccessToken, refreshToken } from "./util/spotify.ts";
 import { useEffect, useState } from "react";
 import Main from "./components/Main.tsx";
-import {Equalizer} from "./components/Equalizer.tsx";
 
 function App() {
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -15,10 +11,6 @@ function App() {
   const [isSpotifySDKReady, setIsSpotifySDKReady] = useState<boolean>(false);
   const [resetTrigger, setResetTrigger] = useState<number>(0);
   const [showSmallHeader, setShowSmallHeader] = useState(false);
-
-  window.onSpotifyWebPlaybackSDKReady = () => {
-    setIsSpotifySDKReady(true);
-  };
 
   const queryParameters = new URLSearchParams(window.location.search);
   const newCode = queryParameters.get("code");
@@ -29,6 +21,14 @@ function App() {
 
   // useEffect to make sure this happens exactly once
   useEffect(() => {
+    window.onSpotifyWebPlaybackSDKReady = () => {
+      setIsSpotifySDKReady(true);
+    };
+    const script = document.createElement("script");
+    script.src = "https://sdk.scdn.co/spotify-player.js";
+    script.async = true;
+    document.body.appendChild(script);
+
     const reloadTokens = () => {
       const expiresAt = window.localStorage.getItem(
         "spotifyAccessTokenExpiresAt",
@@ -51,24 +51,26 @@ function App() {
   }, []);
 
   return (
-    <div className="min-h-screen bg-black flex flex-col items-center justify-center p-4">
-      <Header
-        onLogoClick={() => {
-          setResetTrigger((prev) => prev + 1);
-        }}
-        small={showSmallHeader}
-      />
-      {!isLoading && !accessToken ? <SpotifyLogin /> : null}
-      {accessToken && isSpotifySDKReady ? (
-        <Main
-          accessToken={accessToken}
-          resetTrigger={resetTrigger}
-          isActive={(active) => {
-            setShowSmallHeader(active);
+    <>
+      <div className="min-h-screen bg-black flex flex-col items-center justify-center p-4">
+        <Header
+          onLogoClick={() => {
+            setResetTrigger((prev) => prev + 1);
           }}
+          small={showSmallHeader}
         />
-      ) : null}
-    </div>
+        {!isLoading && !accessToken ? <SpotifyLogin /> : null}
+        {accessToken && isSpotifySDKReady ? (
+          <Main
+            accessToken={accessToken}
+            resetTrigger={resetTrigger}
+            isActive={(active) => {
+              setShowSmallHeader(active);
+            }}
+          />
+        ) : null}
+      </div>
+    </>
   );
 }
 

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -118,6 +118,9 @@ function Main({ accessToken, resetTrigger, isActive }: MainProps) {
     setScannedUrl(null);
     setIsError(false);
     setIsScanning(false);
+    if (spotifyPlayer) {
+      spotifyPlayer.pause();
+    }
   };
 
   if (isError) {

--- a/src/components/PlayingView.tsx
+++ b/src/components/PlayingView.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Equalizer } from "./Equalizer";
+import spotifyLogo from "../assets/img/Spotify_Full_Logo_RGB_Green.png";
 
 interface PlayingViewProps {
   onReset: () => void;
@@ -13,7 +14,7 @@ export const PlayingView: React.FC<PlayingViewProps> = ({
   <div className="bg-black flex flex-col items-center justify-center p-4">
     <div className="flex flex-col items-center relative">
       <img
-        src="/src/assets/img/Spotify_Full_Logo_RGB_Green.png"
+        src={spotifyLogo}
         alt="Spotify Logo"
         className="w-32 mb-4 cursor-pointer hover:scale-105 transition-transform"
         onClick={onReset}

--- a/src/data/config.ts
+++ b/src/data/config.ts
@@ -1,2 +1,2 @@
-export const SPOTIFY_CLIENT_ID = "c83265d4ce9040388f64b9485cf06899";
+export const SPOTIFY_CLIENT_ID = "";
 export const REDIRECT_URL = "http://localhost:4173/";

--- a/src/data/config.ts
+++ b/src/data/config.ts
@@ -1,2 +1,2 @@
-export const SPOTIFY_CLIENT_ID = "";
+export const SPOTIFY_CLIENT_ID = "c83265d4ce9040388f64b9485cf06899";
 export const REDIRECT_URL = "http://localhost:4173/";

--- a/src/util/spotify.ts
+++ b/src/util/spotify.ts
@@ -73,8 +73,7 @@ async function fetchToken(body: URLSearchParams): Promise<void> {
     }
   } catch (error) {
     window.localStorage.removeItem("spotifyAccessToken");
-    window.localStorage.removeItem(
-      "spotifyAccessTokenExpiresAt");
+    window.localStorage.removeItem("spotifyAccessTokenExpiresAt");
     window.localStorage.removeItem("spotifyRefreshToken");
     console.error("Error fetching Spotify access token:", error);
   }


### PR DESCRIPTION
- Load in the Spotify SDK dynamically to make sure the initialization is timed correctly.
- Fixed broken image.
- Clicking the header to go back now also pauses if necessary.